### PR TITLE
Refactor buttons and switch to HTML parse mode

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -11,29 +11,29 @@ owner_filter = filters.user(Config.OWNER_ID)
 @Client.on_message(filters.private & owner_filter & filters.command("approve"))
 async def approve_cmd(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply_text("Usage: /approve <user_id>")
+        await message.reply_text("Usage: /approve <user_id>", parse_mode="HTML")
         return
     user_id = int(message.command[1])
     await update_premium(user_id, True)
     logger.info("User %s approved premium for %s", message.from_user.id, user_id)
-    await message.reply_text("User approved.")
+    await message.reply_text("User approved.", parse_mode="HTML")
 
 
 @Client.on_message(filters.private & owner_filter & filters.command("ban"))
 async def ban_cmd(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply_text("Usage: /ban <user_id>")
+        await message.reply_text("Usage: /ban <user_id>", parse_mode="HTML")
         return
     user_id = int(message.command[1])
     await ban_user(user_id)
     logger.info("User %s banned user %s", message.from_user.id, user_id)
-    await message.reply_text("User banned.")
+    await message.reply_text("User banned.", parse_mode="HTML")
 
 
 @Client.on_message(filters.private & owner_filter & filters.command("broadcast"))
 async def broadcast_cmd(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply_text("Usage: /broadcast <msg>")
+        await message.reply_text("Usage: /broadcast <msg>", parse_mode="HTML")
         return
     text = " ".join(message.command[1:])
     async for user in get_all_users():
@@ -42,10 +42,10 @@ async def broadcast_cmd(client: Client, message: Message):
         except Exception:
             pass
     logger.info("Broadcast from %s sent to all users", message.from_user.id)
-    await message.reply_text("Broadcast sent.")
+    await message.reply_text("Broadcast sent.", parse_mode="HTML")
 
 
 @Client.on_message(filters.private & owner_filter & filters.command("payments"))
 async def payments_cmd(client: Client, message: Message):
     logger.info("%s requested payment logs", message.from_user.id)
-    await message.reply_text("Payment logs not implemented.")
+    await message.reply_text("Payment logs not implemented.", parse_mode="HTML")

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -1,12 +1,13 @@
 from pyrogram import Client, filters
 from pyrogram.types import CallbackQuery
 from utils.logger import logger
-from utils.buttons import MENU_BUTTONS
+from utils.buttons import main_menu_buttons
 
 @Client.on_callback_query(filters.regex("^menu$"))
 async def menu_cb(client: Client, query: CallbackQuery):
     logger.info("User %s opened menu", query.from_user.id)
-    await query.message.edit(
-        "\ud83d\udccc **Main Menu**",
-        reply_markup=MENU_BUTTONS
+    await query.message.edit_text(
+        "<b>\ud83d\udccc Main Menu</b>",
+        reply_markup=main_menu_buttons(),
+        parse_mode="HTML",
     )

--- a/handlers/menu_command.py
+++ b/handlers/menu_command.py
@@ -1,10 +1,14 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message
 from utils.logger import logger
-from utils.buttons import MENU_BUTTONS
+from utils.buttons import main_menu_buttons
 
 
 @Client.on_message(filters.private & filters.command("menu"))
 async def menu_cmd(client: Client, message: Message):
     logger.info("User %s requested menu via command", message.from_user.id)
-    await message.reply("\ud83d\udccc **Main Menu**", reply_markup=MENU_BUTTONS)
+    await message.reply_text(
+        "<b>\ud83d\udccc Main Menu</b>",
+        reply_markup=main_menu_buttons(),
+        parse_mode="HTML",
+    )

--- a/handlers/payments.py
+++ b/handlers/payments.py
@@ -8,16 +8,19 @@ from database import insert_payment
 async def upgrade_cmd(client: Client, message: Message):
     logger.info("User %s requested upgrade info", message.from_user.id)
     await message.reply_text(
-        "Send the amount via UPI and reply with /paid <txn_id> to upgrade."
+        "Send the amount via UPI and reply with /paid <txn_id> to upgrade.",
+        parse_mode="HTML",
     )
 
 
 @Client.on_message(filters.private & filters.command("paid"))
 async def paid_cmd(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply_text("Usage: /paid <txn_id>")
+        await message.reply_text("Usage: /paid <txn_id>", parse_mode="HTML")
         return
     txn_id = message.command[1]
     await insert_payment(message.from_user.id, txn_id)
     logger.info("Payment from %s recorded with txn %s", message.from_user.id, txn_id)
-    await message.reply_text("Payment recorded. Wait for approval.")
+    await message.reply_text(
+        "Payment recorded. Wait for approval.", parse_mode="HTML"
+    )

--- a/handlers/promo.py
+++ b/handlers/promo.py
@@ -1,7 +1,7 @@
 from pyrogram import Client, filters
 from pyrogram.types import CallbackQuery
 from utils.logger import logger
-from utils.buttons import promo_buttons
+from utils.buttons import confirm_join_buttons
 from database import get_user, get_active_group
 
 
@@ -16,8 +16,9 @@ async def promo_cb(client: Client, query: CallbackQuery):
     if not group:
         await query.answer("No groups to show.", show_alert=True)
         return
-    await query.message.edit(
-        f"Join **{group['title']}** and press Done to earn credits.",
-        reply_markup=promo_buttons(group["link"], str(group["_id"]))
+    await query.message.edit_text(
+        f"<b>Join {group['title']} and press Done to earn credits.</b>",
+        reply_markup=confirm_join_buttons(group["link"], str(group["_id"])),
+        parse_mode="HTML",
     )
     logger.info("Sent promo group %s to user %s", group.get('title'), user_id)

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -1,8 +1,12 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message
+from os import getenv
+
 from utils.logger import logger
-from utils.buttons import START_BUTTONS
+from utils.buttons import menu_button
 from database import ensure_user
+
+IMAGE_URL = getenv("IMAGE_URL")
 
 
 @Client.on_message(filters.private & filters.command("start"))
@@ -10,7 +14,12 @@ async def start_cmd(client: Client, message: Message):
     user_id = message.from_user.id
     await ensure_user(user_id)
     logger.info("User %s started bot", user_id)
-    await message.reply_text(
-        f"Hello {message.from_user.mention}! Welcome to the promo bot.",
-        reply_markup=START_BUTTONS
+    await message.reply_photo(
+        IMAGE_URL,
+        caption=(
+            f"<b>Welcome {message.from_user.mention}!</b>\n\n"
+            "Use the button below to open the menu."
+        ),
+        reply_markup=menu_button(),
+        parse_mode="HTML",
     )

--- a/handlers/submit.py
+++ b/handlers/submit.py
@@ -2,13 +2,17 @@ from pyrogram import Client, filters
 from pyrogram.types import CallbackQuery, Message
 from utils.helpers import valid_group_link
 from utils.logger import logger
+from utils.buttons import back_button
 from database import submit_group
 
 
 @Client.on_callback_query(filters.regex("^submit$"))
 async def submit_cb(client: Client, query: CallbackQuery):
-    await query.message.edit("Send your group link.")
-    client.set_parse_mode("markdown")
+    await query.message.edit_text(
+        "<b>Send your group link.</b>",
+        reply_markup=back_button(),
+        parse_mode="HTML",
+    )
     client.data = {}
     client.data[query.from_user.id] = "awaiting_link"
     logger.info("Asked %s for group link", query.from_user.id)
@@ -20,7 +24,7 @@ async def submit_link(client: Client, message: Message):
     if state == "awaiting_link" and valid_group_link(message.text):
         await submit_group(message.from_user.id, message.text, message.text)
         logger.info("User %s submitted group %s", message.from_user.id, message.text)
-        await message.reply_text("Group submitted.")
+        await message.reply_text("<b>Group submitted.</b>", parse_mode="HTML")
         client.data.pop(message.from_user.id, None)
     elif state == "awaiting_link":
-        await message.reply_text("Invalid link.")
+        await message.reply_text("<b>Invalid link.</b>", parse_mode="HTML")

--- a/handlers/user_commands.py
+++ b/handlers/user_commands.py
@@ -9,21 +9,28 @@ async def credits_cmd(client: Client, message: Message):
     user = await get_user(message.from_user.id)
     credits = user.get("credits", 0) if user else 0
     logger.info("User %s checked credits", message.from_user.id)
-    await message.reply_text(f"You have **{credits}** credits.")
+    await message.reply_text(
+        f"<b>You have {credits} credits.</b>", parse_mode="HTML"
+    )
 
 
 @Client.on_message(filters.private & filters.command("mygroup"))
 async def mygroup_cmd(client: Client, message: Message):
     group = await get_group_by_owner(message.from_user.id)
     if group:
-        await message.reply_text(f"Your group: {group['link']}")
+        await message.reply_text(
+            f"<b>Your group:</b> {group['link']}", parse_mode="HTML"
+        )
     else:
-        await message.reply_text("You have not submitted a group.")
+        await message.reply_text(
+            "<b>You have not submitted a group.</b>", parse_mode="HTML"
+        )
 
 
 @Client.on_message(filters.private & filters.command("help"))
 async def help_cmd(client: Client, message: Message):
     logger.info("User %s requested help", message.from_user.id)
     await message.reply_text(
-        "Use /menu to access features and earn credits by joining groups."
+        "Use /menu to access features and earn credits by joining groups.",
+        parse_mode="HTML",
     )

--- a/utils/buttons.py
+++ b/utils/buttons.py
@@ -1,27 +1,47 @@
 from pyrogram.types import InlineKeyboardMarkup, InlineKeyboardButton
 from utils.config import Config
 
-MENU_BUTTONS = InlineKeyboardMarkup([
-    [
-        InlineKeyboardButton("Promote Group", callback_data="promo"),
-        InlineKeyboardButton("Submit Group", callback_data="submit")
-    ],
-    [
-        InlineKeyboardButton("View Stats", callback_data="stats"),
-        InlineKeyboardButton("Upgrade Plan", callback_data="upgrade")
-    ],
-    [
-        InlineKeyboardButton("Support", url=Config.SUPPORT_GROUP),
-        InlineKeyboardButton("Updates", url=Config.SUPPORT_CHANNEL)
-    ]
-])
 
-START_BUTTONS = InlineKeyboardMarkup(
-    [[InlineKeyboardButton("\u27A1 Menu", callback_data="menu")]]
-)
+def main_menu_buttons() -> InlineKeyboardMarkup:
+    """Return the main menu inline keyboard."""
+    return InlineKeyboardMarkup(
+        [
+            [
+                InlineKeyboardButton("🚀 Promote Group", callback_data="promo"),
+                InlineKeyboardButton("➕ Submit Group", callback_data="submit"),
+            ],
+            [
+                InlineKeyboardButton("📊 Stats", callback_data="stats"),
+                InlineKeyboardButton("💎 Upgrade Plan", callback_data="upgrade"),
+            ],
+            [
+                InlineKeyboardButton("🛠 Support", url=Config.SUPPORT_GROUP),
+                InlineKeyboardButton("📢 Updates", url=Config.SUPPORT_CHANNEL),
+            ],
+        ]
+    )
 
-def promo_buttons(link: str, group_id: str) -> InlineKeyboardMarkup:
-    return InlineKeyboardMarkup([
-        [InlineKeyboardButton("Join", url=link)],
-        [InlineKeyboardButton("Done", callback_data=f"done:{group_id}")]
-    ])
+
+def back_button() -> InlineKeyboardMarkup:
+    """Return a back button keyboard."""
+    return InlineKeyboardMarkup(
+        [[InlineKeyboardButton("🔙 Back", callback_data="back")]]
+    )
+
+
+def confirm_join_buttons(group_link: str, group_id: str) -> InlineKeyboardMarkup:
+    """Buttons shown when a user must join a group."""
+    return InlineKeyboardMarkup(
+        [
+            [InlineKeyboardButton("Join", url=group_link)],
+            [InlineKeyboardButton("Done", callback_data=f"done:{group_id}")],
+        ]
+    )
+
+
+def menu_button() -> InlineKeyboardMarkup:
+    """Button used on the /start message to open the menu."""
+    return InlineKeyboardMarkup(
+        [[InlineKeyboardButton("👉 Menu", callback_data="menu")]]
+    )
+


### PR DESCRIPTION
## Summary
- centralize inline button creation
- update start command to send a welcome photo from `IMAGE_URL`
- convert menu and submit handlers to use new buttons
- ensure every message uses HTML parse mode

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686f5b9ec1348329a297e82bb6f438ff