### PR TITLE
Fix pyrogram parse mode errors

### DIFF
--- a/handlers/admin.py
+++ b/handlers/admin.py
@@ -1,5 +1,6 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message
+from pyrogram.enums import ParseMode
 from utils.config import Config
 from utils.logger import logger
 from database import update_premium, ban_user, get_all_users
@@ -11,29 +12,29 @@ owner_filter = filters.user(Config.OWNER_ID)
 @Client.on_message(filters.private & owner_filter & filters.command("approve"))
 async def approve_cmd(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply_text("Usage: /approve <user_id>", parse_mode="HTML")
+        await message.reply_text("Usage: /approve <user_id>", parse_mode=ParseMode.HTML)
         return
     user_id = int(message.command[1])
     await update_premium(user_id, True)
     logger.info("User %s approved premium for %s", message.from_user.id, user_id)
-    await message.reply_text("User approved.", parse_mode="HTML")
+    await message.reply_text("User approved.", parse_mode=ParseMode.HTML)
 
 
 @Client.on_message(filters.private & owner_filter & filters.command("ban"))
 async def ban_cmd(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply_text("Usage: /ban <user_id>", parse_mode="HTML")
+        await message.reply_text("Usage: /ban <user_id>", parse_mode=ParseMode.HTML)
         return
     user_id = int(message.command[1])
     await ban_user(user_id)
     logger.info("User %s banned user %s", message.from_user.id, user_id)
-    await message.reply_text("User banned.", parse_mode="HTML")
+    await message.reply_text("User banned.", parse_mode=ParseMode.HTML)
 
 
 @Client.on_message(filters.private & owner_filter & filters.command("broadcast"))
 async def broadcast_cmd(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply_text("Usage: /broadcast <msg>", parse_mode="HTML")
+        await message.reply_text("Usage: /broadcast <msg>", parse_mode=ParseMode.HTML)
         return
     text = " ".join(message.command[1:])
     async for user in get_all_users():
@@ -42,10 +43,10 @@ async def broadcast_cmd(client: Client, message: Message):
         except Exception:
             pass
     logger.info("Broadcast from %s sent to all users", message.from_user.id)
-    await message.reply_text("Broadcast sent.", parse_mode="HTML")
+    await message.reply_text("Broadcast sent.", parse_mode=ParseMode.HTML)
 
 
 @Client.on_message(filters.private & owner_filter & filters.command("payments"))
 async def payments_cmd(client: Client, message: Message):
     logger.info("%s requested payment logs", message.from_user.id)
-    await message.reply_text("Payment logs not implemented.", parse_mode="HTML")
+    await message.reply_text("Payment logs not implemented.", parse_mode=ParseMode.HTML)

--- a/handlers/menu.py
+++ b/handlers/menu.py
@@ -1,5 +1,6 @@
 from pyrogram import Client, filters
 from pyrogram.types import CallbackQuery
+from pyrogram.enums import ParseMode
 from utils.logger import logger
 from utils.buttons import main_menu_buttons
 
@@ -9,5 +10,5 @@ async def menu_cb(client: Client, query: CallbackQuery):
     await query.message.edit_text(
         "<b>\ud83d\udccc Main Menu</b>",
         reply_markup=main_menu_buttons(),
-        parse_mode="HTML",
+        parse_mode=ParseMode.HTML,
     )

--- a/handlers/menu_command.py
+++ b/handlers/menu_command.py
@@ -1,5 +1,6 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message
+from pyrogram.enums import ParseMode
 from utils.logger import logger
 from utils.buttons import main_menu_buttons
 
@@ -10,5 +11,5 @@ async def menu_cmd(client: Client, message: Message):
     await message.reply_text(
         "<b>\ud83d\udccc Main Menu</b>",
         reply_markup=main_menu_buttons(),
-        parse_mode="HTML",
+        parse_mode=ParseMode.HTML,
     )

--- a/handlers/payments.py
+++ b/handlers/payments.py
@@ -1,5 +1,6 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message
+from pyrogram.enums import ParseMode
 from utils.logger import logger
 from database import insert_payment
 
@@ -9,18 +10,18 @@ async def upgrade_cmd(client: Client, message: Message):
     logger.info("User %s requested upgrade info", message.from_user.id)
     await message.reply_text(
         "Send the amount via UPI and reply with /paid <txn_id> to upgrade.",
-        parse_mode="HTML",
+        parse_mode=ParseMode.HTML,
     )
 
 
 @Client.on_message(filters.private & filters.command("paid"))
 async def paid_cmd(client: Client, message: Message):
     if len(message.command) < 2:
-        await message.reply_text("Usage: /paid <txn_id>", parse_mode="HTML")
+        await message.reply_text("Usage: /paid <txn_id>", parse_mode=ParseMode.HTML)
         return
     txn_id = message.command[1]
     await insert_payment(message.from_user.id, txn_id)
     logger.info("Payment from %s recorded with txn %s", message.from_user.id, txn_id)
     await message.reply_text(
-        "Payment recorded. Wait for approval.", parse_mode="HTML"
+        "Payment recorded. Wait for approval.", parse_mode=ParseMode.HTML
     )

--- a/handlers/promo.py
+++ b/handlers/promo.py
@@ -1,5 +1,6 @@
 from pyrogram import Client, filters
 from pyrogram.types import CallbackQuery
+from pyrogram.enums import ParseMode
 from utils.logger import logger
 from utils.buttons import confirm_join_buttons
 from database import get_user, get_active_group
@@ -19,6 +20,6 @@ async def promo_cb(client: Client, query: CallbackQuery):
     await query.message.edit_text(
         f"<b>Join {group['title']} and press Done to earn credits.</b>",
         reply_markup=confirm_join_buttons(group["link"], str(group["_id"])),
-        parse_mode="HTML",
+        parse_mode=ParseMode.HTML,
     )
     logger.info("Sent promo group %s to user %s", group.get('title'), user_id)

--- a/handlers/start.py
+++ b/handlers/start.py
@@ -1,5 +1,6 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message
+from pyrogram.enums import ParseMode
 from os import getenv
 
 from utils.logger import logger
@@ -21,5 +22,5 @@ async def start_cmd(client: Client, message: Message):
             "Use the button below to open the menu."
         ),
         reply_markup=menu_button(),
-        parse_mode="HTML",
+        parse_mode=ParseMode.HTML,
     )

--- a/handlers/submit.py
+++ b/handlers/submit.py
@@ -1,5 +1,6 @@
 from pyrogram import Client, filters
 from pyrogram.types import CallbackQuery, Message
+from pyrogram.enums import ParseMode
 from utils.helpers import valid_group_link
 from utils.logger import logger
 from utils.buttons import back_button
@@ -11,7 +12,7 @@ async def submit_cb(client: Client, query: CallbackQuery):
     await query.message.edit_text(
         "<b>Send your group link.</b>",
         reply_markup=back_button(),
-        parse_mode="HTML",
+        parse_mode=ParseMode.HTML,
     )
     client.data = {}
     client.data[query.from_user.id] = "awaiting_link"
@@ -24,7 +25,7 @@ async def submit_link(client: Client, message: Message):
     if state == "awaiting_link" and valid_group_link(message.text):
         await submit_group(message.from_user.id, message.text, message.text)
         logger.info("User %s submitted group %s", message.from_user.id, message.text)
-        await message.reply_text("<b>Group submitted.</b>", parse_mode="HTML")
+        await message.reply_text("<b>Group submitted.</b>", parse_mode=ParseMode.HTML)
         client.data.pop(message.from_user.id, None)
     elif state == "awaiting_link":
-        await message.reply_text("<b>Invalid link.</b>", parse_mode="HTML")
+        await message.reply_text("<b>Invalid link.</b>", parse_mode=ParseMode.HTML)

--- a/handlers/user_commands.py
+++ b/handlers/user_commands.py
@@ -1,5 +1,6 @@
 from pyrogram import Client, filters
 from pyrogram.types import Message
+from pyrogram.enums import ParseMode
 from utils.logger import logger
 from database import get_user, get_group_by_owner
 
@@ -10,7 +11,7 @@ async def credits_cmd(client: Client, message: Message):
     credits = user.get("credits", 0) if user else 0
     logger.info("User %s checked credits", message.from_user.id)
     await message.reply_text(
-        f"<b>You have {credits} credits.</b>", parse_mode="HTML"
+        f"<b>You have {credits} credits.</b>", parse_mode=ParseMode.HTML
     )
 
 
@@ -19,11 +20,11 @@ async def mygroup_cmd(client: Client, message: Message):
     group = await get_group_by_owner(message.from_user.id)
     if group:
         await message.reply_text(
-            f"<b>Your group:</b> {group['link']}", parse_mode="HTML"
+            f"<b>Your group:</b> {group['link']}", parse_mode=ParseMode.HTML
         )
     else:
         await message.reply_text(
-            "<b>You have not submitted a group.</b>", parse_mode="HTML"
+            "<b>You have not submitted a group.</b>", parse_mode=ParseMode.HTML
         )
 
 
@@ -32,5 +33,5 @@ async def help_cmd(client: Client, message: Message):
     logger.info("User %s requested help", message.from_user.id)
     await message.reply_text(
         "Use /menu to access features and earn credits by joining groups.",
-        parse_mode="HTML",
+        parse_mode=ParseMode.HTML,
     )


### PR DESCRIPTION
## Summary
- use `ParseMode.HTML` constant instead of string
- import `ParseMode` from Pyrogram enums

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_686f6551cb8483298d870d15add33837